### PR TITLE
#174 design tokens for logo size dont work as expected

### DIFF
--- a/odbp.client/src/assets/_mixin-theme.scss
+++ b/odbp.client/src/assets/_mixin-theme.scss
@@ -1,4 +1,9 @@
 @mixin gpp-woo-theme {
+  // --gpp-woo-page-header
+  --gpp-woo-header-gap: 1rem;
+  --gpp-woo-header-padding-inline-end: 0;
+  --gpp-woo-header-padding-inline-start: 0;
+
   // gpp-woo-page-footer
   --gpp-woo-page-footer-link-list-column-gap: var(--utrecht-space-inline-3xl);
 

--- a/odbp.client/src/assets/_mixin-theme.scss
+++ b/odbp.client/src/assets/_mixin-theme.scss
@@ -1,6 +1,7 @@
 @mixin gpp-woo-theme {
   // --gpp-woo-page-header
   --gpp-woo-header-gap: 1rem;
+  --gpp-woo-header-align-items: end;
   --gpp-woo-header-padding-inline-end: 0;
   --gpp-woo-header-padding-inline-start: 0;
 

--- a/odbp.client/src/assets/design-tokens.scss
+++ b/odbp.client/src/assets/design-tokens.scss
@@ -14,10 +14,10 @@
   --utrecht-page-header-background-color: var(--utrecht-color-white);
   --utrecht-nav-bar-background-color: transparent;
 
-  --utrecht-logo-max-block-size: auto;
-  --utrecht-logo-max-inline-size: 24rem;
-  --utrecht-logo-min-block-size: 3rem;
-  --utrecht-logo-min-inline-size: 18rem;
+  --utrecht-logo-max-block-size: 5rem;
+  --utrecht-logo-max-inline-size: 15rem;
+  --utrecht-logo-min-block-size: 4rem;
+  --utrecht-logo-min-inline-size: 12rem;
 
   --utrecht-unordered-list-marker-color: var(--utrecht-color-blue-35);
 

--- a/odbp.client/src/assets/main.scss
+++ b/odbp.client/src/assets/main.scss
@@ -35,27 +35,6 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  header {
-    margin-block: 1px;
-    padding-inline: 0;
-
-    img {
-      display: block;
-    }
-
-    nav {
-      inline-size: auto;
-    }
-
-    @media screen and (min-width: #{variables.$breakpoint-md}) {
-      & {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
-      }
-    }
-  }
-
   .visually-hidden {
     position: absolute !important;
     overflow: hidden;

--- a/odbp.client/src/components/TheHeader.vue
+++ b/odbp.client/src/components/TheHeader.vue
@@ -45,7 +45,9 @@ const svg = computed(() => {
 .utrecht-page-header {
   grid-template-columns: 1fr;
   align-items: end;
-  padding-inline: 0;
+  gap: var(--gpp-woo-header-gap);
+  padding-inline-end: var(--gpp-woo-header-padding-inline-end);
+  padding-inline-start: var(--gpp-woo-header-padding-inline-start);
 
   @media screen and (min-width: #{variables.$breakpoint-md}) {
     & {

--- a/odbp.client/src/components/TheHeader.vue
+++ b/odbp.client/src/components/TheHeader.vue
@@ -38,3 +38,19 @@ const svg = computed(() => {
   return (document.getElementById(svgTemplateId) as HTMLTemplateElement)?.innerHTML;
 });
 </script>
+
+<style lang="scss" scoped>
+@use "@/assets/variables";
+
+.utrecht-page-header {
+  grid-template-columns: 1fr;
+  align-items: end;
+  padding-inline: 0;
+
+  @media screen and (min-width: #{variables.$breakpoint-md}) {
+    & {
+      grid-template-columns: 1fr auto;
+    }
+  }
+}
+</style>

--- a/odbp.client/src/components/TheHeader.vue
+++ b/odbp.client/src/components/TheHeader.vue
@@ -44,8 +44,8 @@ const svg = computed(() => {
 
 .utrecht-page-header {
   grid-template-columns: 1fr;
-  align-items: end;
   gap: var(--gpp-woo-header-gap);
+  align-items: var(--gpp-woo-header-align-items);
   padding-inline-end: var(--gpp-woo-header-padding-inline-end);
   padding-inline-start: var(--gpp-woo-header-padding-inline-start);
 

--- a/odbp.client/src/features/publicatie/PublicatieDetails.vue
+++ b/odbp.client/src/features/publicatie/PublicatieDetails.vue
@@ -38,7 +38,7 @@
         </utrecht-table>
       </gpp-woo-table-container>
 
-      <gpp-woo-table-container>
+      <gpp-woo-table-container v-if="documenten.length">
         <utrecht-heading :level="2" :id="headingId">Documenten bij deze publicatie</utrecht-heading>
 
         <utrecht-table :aria-labelledby="headingId" class="utrecht-table--alternate-row-color">


### PR DESCRIPTION
#174
- removed flexbox from header to have more predictable logo sizing from tokens
- added some tokens to configure header behaviour
- plus: hide documents table on publicatie-page when no documents available