### PR TITLE
Header-opmaak kunnen verwijderen and vulnerability fixes CKEditor 

### DIFF
--- a/odbp.client/package-lock.json
+++ b/odbp.client/package-lock.json
@@ -103,482 +103,484 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.4.0.tgz",
-      "integrity": "sha512-g90RXXOoyBL0hsUMo6/IsCKF6qlKtxYlwzeTch+XboZOxkvJmozETKY4mnkR+XI1xZeO1bqqzLe8sKiFRvG7Hg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.6.2.tgz",
+      "integrity": "sha512-WeYQHtGlxbuAZE2Uvi0t9A9Punb/jCBinsHvfNZ2a15AT9OvoANHx5XuvViikl9eGmkN6xErj3JzTTDPoqIcqg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-upload": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-upload": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.4.0.tgz",
-      "integrity": "sha512-MI4PrumF62HZ5kG824WOhqtntDS6oPhmlFwg2vOd8L8fW1Gn4SgigvhqxARLi/OIf0ExnNcXFunS30B6lz1Ciw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.6.2.tgz",
+      "integrity": "sha512-is7p5+JboGUH2auOzeLti/rGBQL8WmUSOXiUjI54CVrwLX24Tg569EA4SeuCSvGQbc7upUQtXzjV+3bAKr5gQw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.4.0.tgz",
-      "integrity": "sha512-dYjPpSaIt8z8d7em+I54+S6Y0m/4fXX27DF6gXMHG+79TIzZxakHK096RJBxj3cIjpzSjHI+v9FQ1Y+nO/M79Q==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.6.2.tgz",
+      "integrity": "sha512-0L2f6nVLfnpaWj7iQWmIKVbitb39jfj6ldduuR9dZbTQqGXkE4EbGqD5NLcbrFSMUW826umEfPbYg9pD2P80+Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-heading": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-heading": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.4.0.tgz",
-      "integrity": "sha512-1DpjdGn+xXfYoeDd6SIcQbkUiOeHQbjN7qmjQWrd6JvowQ6loPtDPGL9OHmL4OFubrVn5GM4dS3E1+cU29SVHg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.6.2.tgz",
+      "integrity": "sha512-v2zqJaw2YkB4VAWXecYgIOFMurtXyOweqp1TB6QdoRUKfaI6pmQ6HwiSrnQxCcEZq5J8e53gwfHqWfgmB4TDrQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.4.0.tgz",
-      "integrity": "sha512-nCVP7W5ryshBG7UfXuFRv58qb/HmSS9Gjb2UUM84ODLOjYPFxvzWgQ5bV5t+x1bYAT8z/Xqfv9Ycs9ywEwOA9A==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.6.2.tgz",
+      "integrity": "sha512-v/d3WcRAENVUOAuVuQEUJuksnX0q/cHRi3Xh5tv0U/WQDjTHzcYYj3bHp18erEuEhO08Kt9j+9wBbYmDPNAntg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.4.0.tgz",
-      "integrity": "sha512-B1iX0p5ByU/y7AVREgevr0Kfobt9uT1n9rtXToXbA9W4u4yZIVJULpceTgDw+/OJNU8lyKbq/S/6trjYFsyf0Q==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.6.2.tgz",
+      "integrity": "sha512-Vlnq7Muj6d+Jxg23n9Dm3OA0fH8LVcTv5QT4uaxktrxbqDS7aaHKlHQh9OCW4ohzs4yLmGXAiuSO/wMmY4yW0g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.4.0.tgz",
-      "integrity": "sha512-XBAOfYpy0TdVqAXsBgKSKCD46S7kR/oohqP9UKTGUGrNjojW6FS1k1IxvcpRVATn0xPHjZld58wkwizIdeJveg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.6.2.tgz",
+      "integrity": "sha512-Smn5CPafHkS/7J3olZ+XWKNASoXFh4PC0lQ5W4GWcOF4xSHYkK+O69hPPsLB3WmSzOuEF2iRimoNBiT3769gyQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-link": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-link": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.4.0.tgz",
-      "integrity": "sha512-Utk9nYwzVRLQXYVVR+oi3x4xN7C0lzt+ZUyPjBRf3k60ijP/OpA8lsJJWzonuEEsdELsLzaBNSivTa9hjLZLDA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.6.2.tgz",
+      "integrity": "sha512-3Lvdi/ngqLkDZraY4+y7N5OYB3QZwkiUGNnfTpxoyAsx+rARHl0Os+9n0oe3orMWPsE6tOAv/Y1xGe3x2Zyoug==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-image": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-upload": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-image": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-upload": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "blurhash": "2.0.5",
-        "ckeditor5": "47.4.0",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.4.0.tgz",
-      "integrity": "sha512-jXWwDfzFOn2S/oK84Io6cB7I0W9I7CwMyBfg5YbCEhYtv5aeNQBpRqwik/5cfmMrBMBXrPu1QRs60NIwegk/Eg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.6.2.tgz",
+      "integrity": "sha512-1xXVw/R3wbsjzK/5gx2TRHqAtB8VBNx6ZKZrR1xbEkn6QSgIleLyKSDX55r3D9rH3bAJ6Simh62e+dRi7caxIw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-image": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-image": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.4.0.tgz",
-      "integrity": "sha512-LUR5yTXjHxLn8YLKrJj4/DBtqk6zdPg5SAVXkpNSz5UxU63aaj/L7jKCInr36Uy23Ov5TgT6FkgXPaBtakAqDA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.6.2.tgz",
+      "integrity": "sha512-Ufwo9j8TymmDLMUeTtV2uX3+KjpyK8ikWtQUxqhAs+Lkar4NXYioWjIcQHW7JsersNDae6WlAyEshrhUcxZi1g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.4.0.tgz",
-      "integrity": "sha512-6xUiyoMkcW8F/8OJrEGeKrMixRGLeQYHxij7tYyrXUqugdCJmZ5WNfvsoyVBwk7g3XQDSKnfKG28gSVBPirwBQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.6.2.tgz",
+      "integrity": "sha512-u0AwAfzHDZxp6EqCfHf2u8I36LBWBYp+2iEWE7+VI8jwsdyy08Ow6m75ZbPGzE+W2rC9zSFXCzDiLr04EhAIWA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.4.0.tgz",
-      "integrity": "sha512-lfZd1Zu6FvHbOEXa1yJnuRDK0jYXZR0OaV9ek6A2ZQ6Z169Brc+aH1sTakw7r6S8m1clTz+vRH3UuVk7ETsQGA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.6.2.tgz",
+      "integrity": "sha512-fEGBiVuR9wszB/9OjY2npzIAdIiLy2pzltAfe9CW+lV599ci7S0s5QAfRGjg0aCHnwT9uJ6uE2BJiUsw9+ybPw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.4.0.tgz",
-      "integrity": "sha512-upV/3x9fhgFWxVVtwR47zCOAvZKgP8a8N7UQOFwfs3Tr52+oE1gULWKTiS9079MBaXaIqtM/EbelNdvBh4gOGg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.6.2.tgz",
+      "integrity": "sha512-Ra28vjVeciLH9Md2Pv5WFZ91M0hr5V0FJOAi7A/aVHbroVTdc8lyCW0Fxg49T4SM511hYsJ51FNhJqOZo1OAsQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-watchdog": "47.4.0",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-watchdog": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.4.0.tgz",
-      "integrity": "sha512-YMxvD3Gh6kVux1OKdtdubvjtUHu4TIN7YgCThqsfnuumpnx94Dhq3+wy8o/dO73dRcq/iVvb/9LmkivT4+8uXg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.6.2.tgz",
+      "integrity": "sha512-S71X9Uv+9vDSUKXJbCXXP/elBAxIxjExUrfWm/YV8nPCZKL+p6uUguo9WgNSCDUJDm/FDjjz8ageLisEFEIVvg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-upload": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-cloud-services": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-upload": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.4.0.tgz",
-      "integrity": "sha512-FZuHy5EhzssTQZTuXQF7aVRJyvY0QaIOr6yj8fttRoWQgIDMzJNm+rVW9C9FRa1+j1i9tlrE21+GYIhCgEGyOg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.6.2.tgz",
+      "integrity": "sha512-4TLf2iOcKVpoK7QdiYCzpOpakhgeuoHeWC40wE++SqcCNzdul/8vQ8cf9QFWC3+WoYAFbJ4lljjuFyjrDGofNQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.4.0.tgz",
-      "integrity": "sha512-b698aEHRJSC4jMP0fYD78tdqMw5oQHtCpUL6lU8LFsysCe5M0cqgab4V0hEjeIsg4Ft/UmkgFd1aAleRCDftJg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.6.2.tgz",
+      "integrity": "sha512-nhb6bkxk4YMPp36KenoFxSLJS9c+gm7C79m0reLU5Ohe2do6R++XQcSQ5CfMPAVNgxLZ/MVbAshTZjTsrUoD/Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.4.0.tgz",
-      "integrity": "sha512-4Nk/fe5Sob9aUf8gf4K7GQjqI0XftDThGRjX1eKOSDs+OGXRyB4Fxtu+tHLCyCt8cITac/PAMWaO7dwqbAK8bA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.6.2.tgz",
+      "integrity": "sha512-694K2EwoBH+4oDvDrOk8Bxz/d30hessYZkZ+qUx0Zdlyhcwb5kGLBa+rmPx7txH8StAef4Vmn47QChqMPzo5TQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.4.0.tgz",
-      "integrity": "sha512-/xKtAwq0Pg3Zq7q9QcmrUnqc8XScrUlixWnl58gOxsdmflaSaK4qLtnId0FmSrax0tqVp1qihsUfvE5uUNnyGg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.6.2.tgz",
+      "integrity": "sha512-NRM7uvwb6ZW1zwFucPnA67OzVst+NPx+VDqLIcY4gMAxbFlBrLk+Cb/k1lPW2Vs6E9foMV1LhaEjoHFNzjHKOA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.4.0.tgz",
-      "integrity": "sha512-gKYQeg2QI+9JM2gujYVBaLVlh7Dw4XfkX1g4jYMEqq4YG5E17Hpbc1A/IqUb0LLpAd1TG64AR4s/vxK0JrnY1g==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.6.2.tgz",
+      "integrity": "sha512-INKZT6xC0cXmM18vgoewURSnz/S3Fal07QcjtRCmgSCGNTwKg/GkPKJ8oQrowsKy7zJUPXxSpKFGR1skfjRlfQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.4.0.tgz",
-      "integrity": "sha512-PbTqvbBzMfvKaxTzAt72VskT8ifGoKRNKzskEmm74RCLu6a60rUaqL/4ChkTsF1FKPvB07VDbyDQx4XkvUOBIA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.6.2.tgz",
+      "integrity": "sha512-tkM7Z0nATuJTm73kr2SvsZPB7XkluhfdFVI+lZX+mFEqb+w+SjcEA9ex7naPQmK69Dn0ent5w70MFpKBvj4EJA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-mention": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-mention": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5",
         "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.4.0.tgz",
-      "integrity": "sha512-U3Zq3qZ86Si6L4BslJIXotK9oVXu59zAuDVWlx3prAUS5Mrz7MfVlWdz9HeWu9W1i2FmUGVksX+uoO/ng2CZUA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.6.2.tgz",
+      "integrity": "sha512-HAZIX0clN3ZgRWtffjGdZ0PQ7xaXGmVcnAAHwuOk6gwIFkwJHprOZiKGEySwFEwnfo5NF9steWrPf56tB47keQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.4.0.tgz",
-      "integrity": "sha512-BQjJ7CjXENoF8Inv8ydRl+luRMKQvw1ohkiYsTEruHjGKkAFyDTGrorzkoGp2IU98n5SVGJE+XwVxpKgjsKAVQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.6.2.tgz",
+      "integrity": "sha512-jktgH3AGomON6YEl1N8qJZdckAidMjCYHWIE6A6JYgMJUB1ArM1nmwELNbBywFfp6oSXteRta4FegPy94nu5XA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.4.0.tgz",
-      "integrity": "sha512-M+8xGJF+PKEcTjTeqofNe6cjcTnsy6EomqwGrbHDHhyAXC4d8k/vRrptymjonW7H9IsuOcQ5t2eZj3d+yl03gg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.6.2.tgz",
+      "integrity": "sha512-QKHA2Yf3TA3mdySWjCls5C/V2cG2D+F0W6ifXQlFSPBAlRgfDf7zVnuXBAHHCXcBI2lAssHkxjxz4FaArQcmXg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-select-all": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-undo": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-select-all": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-undo": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.4.0.tgz",
-      "integrity": "sha512-CZAX1XxrJcnOAwENfw4x4DiLyZ6uOHUHJqFXyyJdQC9qfEizvFYTXn3zO6fbViyDd/k4ugAoLBjpaZh6p9FyOQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.6.2.tgz",
+      "integrity": "sha512-z1S4x+gonSgnnSe+MWdYi/eO59EvPvP16Legi0XRk5zMdd7Lgk57YLFEw9klkxeeEjNfKSq1Y8sIWV1MbmtRLA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.4.0.tgz",
-      "integrity": "sha512-QRIThyZg0kT1R4LTotD6cV9gm0NX3Z0Cq/IOQtuwTbRb3wa+kWXhVfKZPV9Qru5HifvrCrcWXMjkBRRIdfqp+Q==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.6.2.tgz",
+      "integrity": "sha512-sQMLwKV/K7NqsucOVKuMUuTO+BCAimQBwc6nIFp2YdArSEOTgnSdHvUvFaFTaL7ipwWE7glaN+6KlhV421QT+A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-fullscreen": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.4.0.tgz",
-      "integrity": "sha512-DdroZD1cgNU3up74ZQq84vXyCDknQJJyyxQIXS5CKJy7qNR9YmixpVmyXpYJmZzdSVvp/p8Ej87VlOXfju3ilQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.6.2.tgz",
+      "integrity": "sha512-Djf7vdWoZX16GTPMCj0ULwk7c9FlMnadfA4bJtB6UQiXs/IP+rsWqCO0TsWzl/gUyPhYffupI03gvR+nKfqRLA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.4.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.4.0.tgz",
-      "integrity": "sha512-VWBxQ2ngrT0x50Tb1klZyIOykgNPby8sw5rBq/nv/UXBb2Ql/crp50miC8pBCOvkbTP16qzVbl5HoiltJQkH/g==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.6.2.tgz",
+      "integrity": "sha512-qa87vYy8JXy5q+/o17jObVl2fzdxqOYMYblT0fks8Uqgj46TVUq9kdmHcA832RR4BUGTKQpRMWOPv2ukWhKpBA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-paragraph": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-paragraph": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.4.0.tgz",
-      "integrity": "sha512-SHBkoMVu/uTkvE0/1zaehlvCpEqYuh/u1Rh7SHNysrD05Nacs1t5jw+l2lTFoyJnhTy+RA9IONYSDF+5tK3dqQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.6.2.tgz",
+      "integrity": "sha512-6jhnlxax4RAV9gbShe7buBWfAZ2L4KE3w20VwKX5zzgr7LMnoro8QkyzSmCEicKWD3zq+pkohYHbIAWr+Gakvg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.4.0.tgz",
-      "integrity": "sha512-UvL0x55QxRGiem8EPO9n/WQk6218TDNatKSCRueZkAYUrFC1bmtVs9g6GqvSl59RoRGcTxVcz0fXbsxrhZY6HA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.6.2.tgz",
+      "integrity": "sha512-3rZohQ4kFIED0ARr/fBROMChsZgx+Sns0Zin0zrjC3znf8T0Dr3T4x/FPTIlSROtLpNcZ25NebCMb6s4o0iS2Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.4.0.tgz",
-      "integrity": "sha512-SnidyadvuC0ohT2kZ0crsnFy8adQwhHcRaGUNXx5qAHRK7K1wGp3nxdnyOW5GdK2CIe8DTo+H3v8nXfvt7VgnQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.6.2.tgz",
+      "integrity": "sha512-OV8mCHq55oKCm6SXNkdt7HBJFD5uT1bhx1p6JIdXY3aLEM8CuyPg016/lsnFMbxnd6v0Gq3nE/gfmbTXC2IWxg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.4.0.tgz",
-      "integrity": "sha512-SGd6wvPB9VGNqEWvoEdK1kQJ3lpvrTNfsA5Pg02V/Zr3gIxnAqajYEArWDYtsz3ajaUDs06i1tFdpCbFB7JRMg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.6.2.tgz",
+      "integrity": "sha512-qsVxQ5fP5Ja5pq5kTV26EprXBGPOP3uFJqbzyc7DA/TVutdAFKo8/C96Rm8kTSJpS7tViFwBr8qMA+lhTJ2wcw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-heading": "47.4.0",
-        "@ckeditor/ckeditor5-image": "47.4.0",
-        "@ckeditor/ckeditor5-list": "47.4.0",
-        "@ckeditor/ckeditor5-remove-format": "47.4.0",
-        "@ckeditor/ckeditor5-table": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-heading": "47.6.2",
+        "@ckeditor/ckeditor5-image": "47.6.2",
+        "@ckeditor/ckeditor5-list": "47.6.2",
+        "@ckeditor/ckeditor5-remove-format": "47.6.2",
+        "@ckeditor/ckeditor5-table": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-icons": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.4.0.tgz",
-      "integrity": "sha512-2THOymXou/dBR+Jk69+/DzE3lK3QVk8+9eSKdWQ4+kvYom9MXT9RwKJNe3BlvqUNxBymI8eVBjdaQjfv3AOT0Q==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.6.2.tgz",
+      "integrity": "sha512-sMw14Zwsyls9qjSTEyPA1V8mAmr/amU2u0L2XPfLU6lEiyYZT5rGYrcaKLZcPjOfCA1OLEx6Ae3kS38Hpse1+w==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.4.0.tgz",
-      "integrity": "sha512-Z0q+cANAvzvW/3lIMg0rpvVHx4nlWbUsfPw78gM7/DmB4qpdbKsX07iTut84ZnWvOP+WU3XIrhinMXTvl6IqEw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.6.2.tgz",
+      "integrity": "sha512-qH+yGRva8n/9lVBHJZi5FdPxeDz6xNBeZNam/ef7OHDHwDrY2D7sCjwmtRjtbwphDUt7dogp//NfTQEUpcQIsA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-undo": "47.4.0",
-        "@ckeditor/ckeditor5-upload": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-undo": "47.6.2",
+        "@ckeditor/ckeditor5-upload": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.4.0.tgz",
-      "integrity": "sha512-lFPYPUSuByK6GHiTnkHeLkWHD5/SbXCQ5TJVzRJ3uaWvbqo0b0Hvoz92vtKueOwi1QsgXD38aYhMljs0h8eP5g==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.6.2.tgz",
+      "integrity": "sha512-KTzZHYdvwDuwjZDJSXPT/m7NA9gnVj1NojaCdTr1jcF1F0+j4wILmmoRv0qI1COzv2vn9uc61AEou4rwOhDSEw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-heading": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-list": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-heading": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-list": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-integrations-common": {
@@ -594,65 +596,67 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.4.0.tgz",
-      "integrity": "sha512-3FEoS59ZOTm6m0m0O5qEpsf4tGX/r+r0LjkDrRjhIcaGJh0W4Ao2J6cSrXv7hikDpgBjbHIkEy0V6KkIWWAZpg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.6.2.tgz",
+      "integrity": "sha512-v3kx5fgPS6nbsReDlNl54j5XVGqsXFNOUo9e9GktvNQ5w0Vu+fntzMHu3PReHfiizuGH9A+1GZto3ZQ2RcsIsQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.4.0.tgz",
-      "integrity": "sha512-AF7TVV64iOqia4x4psHakYYznPoS3I5j1Gijoa7jiTLGJZSaAL7xAc1qAajgWQ66o7DWuVGL7QkZwKIo1jlTPg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.6.2.tgz",
+      "integrity": "sha512-UJIPewfevj/w5cGPW133Pjkt9Zx1kxr3X3MdNKCtpa6IhnCVJ1iz84hSeMJohgrxW0KaslqiRI6a/y2aiD/KBw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-image": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-image": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.4.0.tgz",
-      "integrity": "sha512-OGvAgS+NB1dzrqhN1xEVfN8PTM73pjMnmDvQeQurwIfjQdJaO07jGPRqujQzNostckWvNPtQysXkbnp+QiCPOw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.6.2.tgz",
+      "integrity": "sha512-4YwM0IJRExbzXQ1PrTxAxj3WbADcjpGZbKqlZv+NspS8gWk8Pglz3pjfYfICS6CVJ0Y+1C8TR46/Tq22j6KeBA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-font": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-font": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.4.0.tgz",
-      "integrity": "sha512-2W1dBzxPIdEsE0CiU19K4xQfBS2jSBruJh5XV924eyuJPh76CdXKDGPBwuVd6i1oK7x+ji0Griu9Y+R2F0jRIw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.6.2.tgz",
+      "integrity": "sha512-kmFjWXT+SbHIdAprxfKgDF4aKWE5doD+QqNTjRWifFoqpb9/Lz+rvCDZw2j1Tavnjtf0a0NY+ZwGaYWvY2zxLA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
         "@types/hast": "3.0.4",
-        "ckeditor5": "47.4.0",
+        "ckeditor5": "47.6.2",
         "hast-util-from-dom": "5.0.1",
         "hast-util-to-html": "9.0.5",
         "hast-util-to-mdast": "10.1.2",
@@ -670,236 +674,236 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.4.0.tgz",
-      "integrity": "sha512-oL/In6Q3dtgj23FyyKbtYa704sl1eEx8JeO4ODRL3scCNI2/7qx9nGMexydiJi+Saulvs/3g7A8PbXiI+iArog==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.6.2.tgz",
+      "integrity": "sha512-3kYexm1NF/QXHIuh5Fj+SWcYTNQ6oEkgheYU7VxwILg9+Y2UoAf4s5TlX2K8yb07tc0bHsIFdjt8F4Nz8oagtw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-undo": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-undo": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.4.0.tgz",
-      "integrity": "sha512-1niRMaI5HxYbSTosxjU/6F5Uo+2hCEa3s18emwIBMTG1zOu0OViubuj+P8wCOqmSmpzvfkNybl4kk74MahGk0w==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.6.2.tgz",
+      "integrity": "sha512-mT8toRkqXbatOx/YAFCnYlPqq6XjMdaUUqg7YqoA/OOjotOfqc4veoJ/BaaPAA043wq9LFjAkkpXhNUouTOOgg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.4.0.tgz",
-      "integrity": "sha512-j0bOrjhEB5U6wCrz8CgW8ueFgHJJORtgqkOiRfQd++SBHGULSRr/WJwvaObcrhhNrY4Mlme8Nws6s5YJxzlFhA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.6.2.tgz",
+      "integrity": "sha512-ACju165gL+VbFARNFoUao5MEHLBsfyU+19Q4Bukv4LufZlpvtJ56UuOzHLlhEoeOVIEAPE4v5cEl0/MVYCn8GA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.4.0.tgz",
-      "integrity": "sha512-v4VR4OhLqj5Rp/Dwb9BSb9lSNAkGVF9n5ThvC0dFeHMikC4ENcqH8NpcbVnaua4tsM9tX0jZLHbcX+jMune4IQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.6.2.tgz",
+      "integrity": "sha512-hUobTNQG8aTWkIZk3ya+3yHw9zXSQqyZdh3NdtQ21fb/lF7V7BVmdJ2lxQF3lZAeQcdax8nkaJj0l9DxRjPnfw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.4.0.tgz",
-      "integrity": "sha512-epw82iXcK6togOeE/rolQBkyxCfz8m30VoH0bdq0YKkg8+HJ5uzB2FweFDH+l/cyoubdB2f1370G2dAMp6huBg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.6.2.tgz",
+      "integrity": "sha512-HfsCPGh56ezS2Vf9kitkrBt4NEGmeSO2yBwSog88RdBQOtqcLhM3Ks6HN3LPZoP7L9LxwekptQh3wVIlU1wjyA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.4.0.tgz",
-      "integrity": "sha512-yKOk+CDV0dAy+XeqUcP5Drur1u69h6UCdLwDUEbS/egSv/+o+tJwCGrTCRzPqBeUxIahUGBMk0obID7v6xT9IQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.6.2.tgz",
+      "integrity": "sha512-9CjNW3Xfhy2AbMw0Ax6VJcAqMJGYwFm3p21MdDMEIWxDL8vmvKxNAGhsQRYvZ3oFHPHn5yTLDFRsKJiRTA8Vrw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.4.0.tgz",
-      "integrity": "sha512-XD6LY76m3bZr/twRGTjNRnU4z0VU1akDC7evVMhRPaDruR71km00VT1YNPRChCDmdssEVeWEynHhLQ/kRjy+0w==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.6.2.tgz",
+      "integrity": "sha512-odaDDJcNwTzvo/VgiMlfk8Om2iCxnG8UcaTmOvY+Qdg9ZZ/B2oC4vdu+RRZ2493HLjDNDO/FjPD4j567aJKUFg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.4.0.tgz",
-      "integrity": "sha512-roywT2jKCs0NVd6TVhYlmrnP0oI4499M5L1mV8Vqq4wc9puVeEPSIKoZNdIF5YWXsHjpCUCMejpuigLTIbf9MQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.6.2.tgz",
+      "integrity": "sha512-FAbyy3IISxGTzFz7xB93+MXX44gMTAeF+ckqkz6wkx6qaxT5xTm9RUzIEV6rQ6lCZ5BAoFlCAPwMw2austn7ew==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.4.0.tgz",
-      "integrity": "sha512-9fVsmNFmSj53kJKPKUmCkgpXUev2OeMJ5cFVKXvzEvsm6jFTO8/9iHRTbN/j/ZzWuK5MoO/I3gVn4wGOIX//zw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.6.2.tgz",
+      "integrity": "sha512-Q38YdkrRRVZ43Wzx3NR8/EJRw8HJ5Q6Dw8I6ZlYYUe1VtXpKruK/nXNsWPs1Ek83eFRK2xoggCcnotHN2DpVFQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.4.0.tgz",
-      "integrity": "sha512-uIFHsH2HMPYRWmK+heZoiXRVqbxFJZwYZY1WmNKjE5g7OM8y+PVowe0ZYICjauV2/Z2rwCWtodDKb1bnVnl+mQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.6.2.tgz",
+      "integrity": "sha512-JiTD0J89j9UeSPWV7y9Y70SYXIRuaqvael/MEAv+ZTN8n6fPlVYY4vR9pVRjYZnajv2b7mJNRPHE07YdEJcWaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.4.0.tgz",
-      "integrity": "sha512-AtamOK+Dya6abkuo9XYME05FYFigBRic5gr3/KzhyFfHh7qiFlZFLCDH0S/JEQ0AduFjfgUx4h0ST22RIhiYoA==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.6.2.tgz",
+      "integrity": "sha512-e4xNQWZu+V04cEjN0z8jGbnT1iIWSho/uMcxC6NehZ8Y25cGmvtexxtYv+5oxIAm36n9ooCLRydiPQ5ONq5y0A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.4.0.tgz",
-      "integrity": "sha512-eYP23WZY8ayA0q8LNVCUcP85yf9J2gSpVE9E6LNIku4rbzox6mCf0sZF0ZhzvqHyXyj9Mn+S21IZpLOTuTUW0g==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.6.2.tgz",
+      "integrity": "sha512-XVM1JNRC9XjS1w7xmVe9IbELyiWjUXfpdz9OtG02HHTYt9dgxarPyOYoCN65qvaqnivF+bpU3jFw6aMKbn5sng==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.4.0.tgz",
-      "integrity": "sha512-R6kt9jX9FOnYRXKn7kX0ZdIdW5A3S7ZZBfcdwzG9O/t7r5IIkp+yhC1y6/uBAc2twvvqMhG7Gu5KH2o/TVVjSg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.6.2.tgz",
+      "integrity": "sha512-shv8BOQinzy30RmwliOcD8aCC8MqVrtJjiQBry2IXZ/WTkbZP4RDZR/uvuKhWvvz8Lk2tC7AEp6V3chSCpQ9oA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-html-support": "47.4.0",
-        "@ckeditor/ckeditor5-list": "47.4.0",
-        "@ckeditor/ckeditor5-table": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-html-support": "47.6.2",
+        "@ckeditor/ckeditor5-list": "47.6.2",
+        "@ckeditor/ckeditor5-table": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.4.0.tgz",
-      "integrity": "sha512-gWraeB14YnpR+ELySu3xgSFlfur07ZBPN76rQuiIobrecKwhh1Az8rk7Qo4c1K/q/f4pHmqh87nhSprn7Mo7+w==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.6.2.tgz",
+      "integrity": "sha512-rTLISHR/YBlkTvso+F4SI4YUz9g+yKNxrHbsBgnMzbWzu96ecA0IVVTD3vg6Bt/xSzyWHdmj95ThMWuqWEJtRw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.4.0.tgz",
-      "integrity": "sha512-kdtwV5HJ+8/oNcsGM8sdpULhXr2TfM7gEKlH/EAdycLDa6topcJuTl7iVSEu4hZzwVo2agiEMmdUIf3dvWweow==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.6.2.tgz",
+      "integrity": "sha512-5NlbqKiwP6o8MrniSJ9SZPQ8eq17wBnH2YU3C8KoU+3/7NYPWgCebew3/xTxIfybvFtkHIDiWAEcy1TIHNpavw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.4.0"
+        "@ckeditor/ckeditor5-ui": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.4.0.tgz",
-      "integrity": "sha512-+YmCUTLVAryK5h68TgQ0qxDngs1MTCLKPDXxHzNqs0oXHai9YkJv/zg4zeb0/RQRIps7jh3bPapZoi2hP2iN3A==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.6.2.tgz",
+      "integrity": "sha512-NDZ1J7g/E7mTUvqnXCloNt7zFtxvidrK4UplyOHGbHSFM1BNRAUc5Sugk3fzxrF8JgKZmKW5CaG2+p2avclbRA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.4.0.tgz",
-      "integrity": "sha512-sL67wp2DX+P3zxeJLo2I7yLhBlX6Zhd0xfUAB6vX6SkjhMeC0L2gLOIr3kKq/OMKEuS+0iZ+qVvEN1j+2Flzlg==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.6.2.tgz",
+      "integrity": "sha512-jpdVYEkY+IenzsFK9TCfiotqDTRbkkitU6nBC3dVOTV8dNAa/oN/mizhtZNUD+mDblhTAVsx7IsjwpKcQgivvw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "@types/color-convert": "2.0.4",
         "color-convert": "3.1.0",
         "color-parse": "2.0.2",
@@ -929,35 +933,35 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.4.0.tgz",
-      "integrity": "sha512-OnxpJb9glDwuSTl59Yb4+6bjWW5h4BA+94YhesKZXeIaXjyzwFmNGxM07nRyaX4KXwGVP5y5JZC2xv5bCOXKSQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.6.2.tgz",
+      "integrity": "sha512-RW1o7yui5/VPkS0IU9KGrVNADsuU33XpAQrquSJZasZabckFOuUxRP3W+CbxhRjHUBygBtBk5naJmEoNjYGglQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.4.0.tgz",
-      "integrity": "sha512-9gMfYltVNi5aYNs8IixTXww9kyU0+oEeY9pN8W6YLrhToVJdnN14pW3yNkQJKJPK7HS2RgM6L1Y+u50qu/IL2g==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.6.2.tgz",
+      "integrity": "sha512-Q7KhQetBuxRly1yquasCS/ONHv8aNANOpFg6xUXlwOrbtFSIQsyLTIXrHXNA+xDzLEqZeGkd8GYa1AIHH5fs5g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0"
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.4.0.tgz",
-      "integrity": "sha512-+5v1k3+8Yr0VUnO+3GfP7MsDCqt5KD9f9Z5wUVRig/J61hPTv8cUQp0859K87IuOLdAP/rZ1iQpdi1psanQeIQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.6.2.tgz",
+      "integrity": "sha512-qClamh5T1XxIBcC/7n2Svhhug6FIc4tilOrIgJbypU8SarWarrL4XrpI2yAv3gSfz23U+QA5CHBR5c08G5lUrA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "47.4.0",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
@@ -979,44 +983,44 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.4.0.tgz",
-      "integrity": "sha512-MEfHIVYV4SILXi++G00y3wREm/1gT5dO+pTGpQY+NNYw8wgi32rg1q8hO2P/upsVaPzbeD3WLURyqeIxKwY20Q==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.6.2.tgz",
+      "integrity": "sha512-r97uTUpn7v5yVFyrhwFUAG6uiLs7px0UG8d8lXPZTUm5XIDLuwCskrqO0r7U26No26V4+ph96QaEulnKeTTWVA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.4.0.tgz",
-      "integrity": "sha512-wffwrMQ6h+Hdu9IMG0H0QAf0YWWn+AGeJwPs69cRjRwB5pNOCUmMyM4h8MtNp15UEvGGARlhOjFf1TniMUkKrw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.6.2.tgz",
+      "integrity": "sha512-XBvyI2qMLTMRFi+B7M6/7/GH7PJw91t6/LqrZkCFclhrmUpa5gZjDdVOpQvArOwot8CGz8sdawL5RBw/DcK2kA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.4.0.tgz",
-      "integrity": "sha512-JeiwHJyBdlUCdzfW3K2KoGO/QhDe1qOKNPXiVXzExIyZpww+hm5HjV/zi5gX4xAvWg9ew0UaQRco5Dy7mBBfRQ==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.6.2.tgz",
+      "integrity": "sha512-fb2Z1zjz32NhMkgA/4wHua6IdaT7Td2FQP9GUqSF5gm53d1L8Yc/Hew5CiVHyWhMBNkdcef1o3a8/MFnP2LOfA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "ckeditor5": "47.4.0",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "ckeditor5": "47.6.2",
         "es-toolkit": "1.39.5"
       }
     },
@@ -1605,9 +1609,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1616,9 +1620,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1676,9 +1680,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1687,9 +1691,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2226,9 +2230,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
-      "integrity": "sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -2240,9 +2244,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz",
-      "integrity": "sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -2254,9 +2258,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz",
-      "integrity": "sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -2268,9 +2272,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz",
-      "integrity": "sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -2282,9 +2286,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz",
-      "integrity": "sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -2296,9 +2300,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz",
-      "integrity": "sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -2310,9 +2314,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz",
-      "integrity": "sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -2324,9 +2328,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz",
-      "integrity": "sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -2338,9 +2342,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz",
-      "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -2352,9 +2356,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz",
-      "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -2365,10 +2369,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz",
-      "integrity": "sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -2379,10 +2383,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz",
-      "integrity": "sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -2394,9 +2426,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz",
-      "integrity": "sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -2408,9 +2440,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz",
-      "integrity": "sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -2422,9 +2454,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz",
-      "integrity": "sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -2436,9 +2468,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
-      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -2450,9 +2482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz",
-      "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -2463,10 +2495,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz",
-      "integrity": "sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -2478,9 +2538,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz",
-      "integrity": "sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -2491,10 +2551,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.0.tgz",
-      "integrity": "sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -4186,9 +4260,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4313,9 +4387,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4456,72 +4530,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "47.4.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.4.0.tgz",
-      "integrity": "sha512-6RTRV2w6nhmBSLBnA0O9QzcBC/Cf74ogziaKHOK61H+PcM6aP3ltb/fNScGyy3NVw3+OzaxjbPF7NSykVmmMMw==",
+      "version": "47.6.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.6.2.tgz",
+      "integrity": "sha512-Ezi+mp/KAAelM8b1P4gbe9xLB6w70MwMQdlj5ZICju++klsbKdPfGM7Ufn0qe1AyEWelTFQQXYZbA+KO/aGxuw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "47.4.0",
-        "@ckeditor/ckeditor5-alignment": "47.4.0",
-        "@ckeditor/ckeditor5-autoformat": "47.4.0",
-        "@ckeditor/ckeditor5-autosave": "47.4.0",
-        "@ckeditor/ckeditor5-basic-styles": "47.4.0",
-        "@ckeditor/ckeditor5-block-quote": "47.4.0",
-        "@ckeditor/ckeditor5-bookmark": "47.4.0",
-        "@ckeditor/ckeditor5-ckbox": "47.4.0",
-        "@ckeditor/ckeditor5-ckfinder": "47.4.0",
-        "@ckeditor/ckeditor5-clipboard": "47.4.0",
-        "@ckeditor/ckeditor5-cloud-services": "47.4.0",
-        "@ckeditor/ckeditor5-code-block": "47.4.0",
-        "@ckeditor/ckeditor5-core": "47.4.0",
-        "@ckeditor/ckeditor5-easy-image": "47.4.0",
-        "@ckeditor/ckeditor5-editor-balloon": "47.4.0",
-        "@ckeditor/ckeditor5-editor-classic": "47.4.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "47.4.0",
-        "@ckeditor/ckeditor5-editor-inline": "47.4.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "47.4.0",
-        "@ckeditor/ckeditor5-emoji": "47.4.0",
-        "@ckeditor/ckeditor5-engine": "47.4.0",
-        "@ckeditor/ckeditor5-enter": "47.4.0",
-        "@ckeditor/ckeditor5-essentials": "47.4.0",
-        "@ckeditor/ckeditor5-find-and-replace": "47.4.0",
-        "@ckeditor/ckeditor5-font": "47.4.0",
-        "@ckeditor/ckeditor5-fullscreen": "47.4.0",
-        "@ckeditor/ckeditor5-heading": "47.4.0",
-        "@ckeditor/ckeditor5-highlight": "47.4.0",
-        "@ckeditor/ckeditor5-horizontal-line": "47.4.0",
-        "@ckeditor/ckeditor5-html-embed": "47.4.0",
-        "@ckeditor/ckeditor5-html-support": "47.4.0",
-        "@ckeditor/ckeditor5-icons": "47.4.0",
-        "@ckeditor/ckeditor5-image": "47.4.0",
-        "@ckeditor/ckeditor5-indent": "47.4.0",
-        "@ckeditor/ckeditor5-language": "47.4.0",
-        "@ckeditor/ckeditor5-link": "47.4.0",
-        "@ckeditor/ckeditor5-list": "47.4.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "47.4.0",
-        "@ckeditor/ckeditor5-media-embed": "47.4.0",
-        "@ckeditor/ckeditor5-mention": "47.4.0",
-        "@ckeditor/ckeditor5-minimap": "47.4.0",
-        "@ckeditor/ckeditor5-page-break": "47.4.0",
-        "@ckeditor/ckeditor5-paragraph": "47.4.0",
-        "@ckeditor/ckeditor5-paste-from-office": "47.4.0",
-        "@ckeditor/ckeditor5-remove-format": "47.4.0",
-        "@ckeditor/ckeditor5-restricted-editing": "47.4.0",
-        "@ckeditor/ckeditor5-select-all": "47.4.0",
-        "@ckeditor/ckeditor5-show-blocks": "47.4.0",
-        "@ckeditor/ckeditor5-source-editing": "47.4.0",
-        "@ckeditor/ckeditor5-special-characters": "47.4.0",
-        "@ckeditor/ckeditor5-style": "47.4.0",
-        "@ckeditor/ckeditor5-table": "47.4.0",
-        "@ckeditor/ckeditor5-theme-lark": "47.4.0",
-        "@ckeditor/ckeditor5-typing": "47.4.0",
-        "@ckeditor/ckeditor5-ui": "47.4.0",
-        "@ckeditor/ckeditor5-undo": "47.4.0",
-        "@ckeditor/ckeditor5-upload": "47.4.0",
-        "@ckeditor/ckeditor5-utils": "47.4.0",
-        "@ckeditor/ckeditor5-watchdog": "47.4.0",
-        "@ckeditor/ckeditor5-widget": "47.4.0",
-        "@ckeditor/ckeditor5-word-count": "47.4.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.6.2",
+        "@ckeditor/ckeditor5-alignment": "47.6.2",
+        "@ckeditor/ckeditor5-autoformat": "47.6.2",
+        "@ckeditor/ckeditor5-autosave": "47.6.2",
+        "@ckeditor/ckeditor5-basic-styles": "47.6.2",
+        "@ckeditor/ckeditor5-block-quote": "47.6.2",
+        "@ckeditor/ckeditor5-bookmark": "47.6.2",
+        "@ckeditor/ckeditor5-ckbox": "47.6.2",
+        "@ckeditor/ckeditor5-ckfinder": "47.6.2",
+        "@ckeditor/ckeditor5-clipboard": "47.6.2",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.2",
+        "@ckeditor/ckeditor5-code-block": "47.6.2",
+        "@ckeditor/ckeditor5-core": "47.6.2",
+        "@ckeditor/ckeditor5-easy-image": "47.6.2",
+        "@ckeditor/ckeditor5-editor-balloon": "47.6.2",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.2",
+        "@ckeditor/ckeditor5-editor-inline": "47.6.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.2",
+        "@ckeditor/ckeditor5-emoji": "47.6.2",
+        "@ckeditor/ckeditor5-engine": "47.6.2",
+        "@ckeditor/ckeditor5-enter": "47.6.2",
+        "@ckeditor/ckeditor5-essentials": "47.6.2",
+        "@ckeditor/ckeditor5-find-and-replace": "47.6.2",
+        "@ckeditor/ckeditor5-font": "47.6.2",
+        "@ckeditor/ckeditor5-fullscreen": "47.6.2",
+        "@ckeditor/ckeditor5-heading": "47.6.2",
+        "@ckeditor/ckeditor5-highlight": "47.6.2",
+        "@ckeditor/ckeditor5-horizontal-line": "47.6.2",
+        "@ckeditor/ckeditor5-html-embed": "47.6.2",
+        "@ckeditor/ckeditor5-html-support": "47.6.2",
+        "@ckeditor/ckeditor5-icons": "47.6.2",
+        "@ckeditor/ckeditor5-image": "47.6.2",
+        "@ckeditor/ckeditor5-indent": "47.6.2",
+        "@ckeditor/ckeditor5-language": "47.6.2",
+        "@ckeditor/ckeditor5-link": "47.6.2",
+        "@ckeditor/ckeditor5-list": "47.6.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.6.2",
+        "@ckeditor/ckeditor5-media-embed": "47.6.2",
+        "@ckeditor/ckeditor5-mention": "47.6.2",
+        "@ckeditor/ckeditor5-minimap": "47.6.2",
+        "@ckeditor/ckeditor5-page-break": "47.6.2",
+        "@ckeditor/ckeditor5-paragraph": "47.6.2",
+        "@ckeditor/ckeditor5-paste-from-office": "47.6.2",
+        "@ckeditor/ckeditor5-remove-format": "47.6.2",
+        "@ckeditor/ckeditor5-restricted-editing": "47.6.2",
+        "@ckeditor/ckeditor5-select-all": "47.6.2",
+        "@ckeditor/ckeditor5-show-blocks": "47.6.2",
+        "@ckeditor/ckeditor5-source-editing": "47.6.2",
+        "@ckeditor/ckeditor5-special-characters": "47.6.2",
+        "@ckeditor/ckeditor5-style": "47.6.2",
+        "@ckeditor/ckeditor5-table": "47.6.2",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.2",
+        "@ckeditor/ckeditor5-typing": "47.6.2",
+        "@ckeditor/ckeditor5-ui": "47.6.2",
+        "@ckeditor/ckeditor5-undo": "47.6.2",
+        "@ckeditor/ckeditor5-upload": "47.6.2",
+        "@ckeditor/ckeditor5-utils": "47.6.2",
+        "@ckeditor/ckeditor5-watchdog": "47.6.2",
+        "@ckeditor/ckeditor5-widget": "47.6.2",
+        "@ckeditor/ckeditor5-word-count": "47.6.2"
       }
     },
     "node_modules/color-convert": {
@@ -4694,9 +4768,9 @@
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -4760,9 +4834,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4776,15 +4850,15 @@
       "license": "MIT"
     },
     "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
-        "minimatch": "9.0.1",
+        "minimatch": "^9.0.1",
         "semver": "^7.5.3"
       },
       "bin": {
@@ -4792,22 +4866,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/emoji-regex": {
@@ -5139,9 +5197,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5163,9 +5221,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5404,9 +5462,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5822,9 +5880,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -6134,16 +6192,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6225,9 +6283,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -7029,13 +7087,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7373,9 +7431,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7711,9 +7769,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
-      "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7727,26 +7785,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.44.0",
-        "@rollup/rollup-android-arm64": "4.44.0",
-        "@rollup/rollup-darwin-arm64": "4.44.0",
-        "@rollup/rollup-darwin-x64": "4.44.0",
-        "@rollup/rollup-freebsd-arm64": "4.44.0",
-        "@rollup/rollup-freebsd-x64": "4.44.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.44.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.44.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.44.0",
-        "@rollup/rollup-linux-arm64-musl": "4.44.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.44.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.44.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.44.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.44.0",
-        "@rollup/rollup-linux-x64-gnu": "4.44.0",
-        "@rollup/rollup-linux-x64-musl": "4.44.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.44.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.44.0",
-        "@rollup/rollup-win32-x64-msvc": "4.44.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -8151,9 +8214,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8518,9 +8581,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8693,9 +8756,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8779,9 +8842,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/odbp.client/src/components/ckeditor/CkEditorAsync.vue
+++ b/odbp.client/src/components/ckeditor/CkEditorAsync.vue
@@ -20,6 +20,11 @@ const config: EditorConfig = {
   heading: {
     options: [
       {
+        model: "paragraph",
+        title: "Normaal",
+        class: "ck-heading_paragraph"
+      },
+      {
         model: "heading1",
         view: { name: "h1", classes: "utrecht-heading-1" },
         title: "Heading 1",


### PR DESCRIPTION
#244 en

## 🔒 Security: `npm audit fix` applied

Resolved **73 vulnerabilities** (9 high · 64 moderate). All fixes were non-breaking version bumps.

> **Note on the count:** 64 of the 73 moderate findings stem from a single XSS vulnerability in `@ckeditor/ckeditor5-html-support` that cascades through the CKEditor 5 package graph. A single version bump resolves all of them.

---

### 🔴 High severity

| Package | Vulnerability | GHSA |
|---|---|---|
| `vite` | Path traversal in optimised deps `.map` handling | [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) |
| `vite` | Arbitrary file read via dev server WebSocket | [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) |
| `rollup` | Arbitrary file write via path traversal (4.0.0–4.58.0) | [GHSA-mw96-cpmx-2vgc](https://github.com/advisories/GHSA-mw96-cpmx-2vgc) |
| `flatted` | Unbounded recursion DoS in `parse()` revive phase | [GHSA-25h7-pfq9-p65f](https://github.com/advisories/GHSA-25h7-pfq9-p65f) |
| `flatted` | Prototype pollution via `parse()` | [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) |
| `lodash` / `lodash-es` | Code injection via `_.template` imports key names | [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) |
| `lodash` / `lodash-es` | Prototype pollution via array path bypass in `_.unset` / `_.omit` | [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) |
| `immutable` | Prototype pollution (v5.0.0–5.1.4) | [GHSA-wf6x-7x77-mvgw](https://github.com/advisories/GHSA-wf6x-7x77-mvgw) |
| `minimatch` | ReDoS via repeated wildcards with non-matching literal | [GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26) |
| `minimatch` | ReDoS via multiple non-adjacent GLOBSTAR segments | [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) |
| `minimatch` | ReDoS via nested `*()` extglobs | [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) |
| `picomatch` | Method injection in POSIX character classes | [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p) |
| `picomatch` | ReDoS via extglob quantifiers | [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) |

> `minimatch` fix also covers `@eslint/config-array`, `@eslint/eslintrc`, `editorconfig`, and `eslint`. `picomatch` fix also covers `tinyglobby`, `vite`, and `vitest`.

---

### 🟡 Moderate severity

| Package | Vulnerability | GHSA |
|---|---|---|
| `@ckeditor/ckeditor5-html-support` + ~60 dependents | XSS in CKEditor 5 HTML Support package — cascades through entire CKEditor ecosystem | [GHSA-jrqm-vmqc-gm93](https://github.com/advisories/GHSA-jrqm-vmqc-gm93) |
| `dompurify` | Cross-site scripting vulnerability | [GHSA-v8jm-5vwx-cfxm](https://github.com/advisories/GHSA-v8jm-5vwx-cfxm) |
| `dompurify` | Mutation-XSS via re-contextualization | [GHSA-h8r8-wccr-v5f2](https://github.com/advisories/GHSA-h8r8-wccr-v5f2) |
| `dompurify` | Cross-site scripting vulnerability | [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv) |
| `dompurify` | `ADD_ATTR` predicate skips URI validation | [GHSA-cjmm-f4jc-qw8r](https://github.com/advisories/GHSA-cjmm-f4jc-qw8r) |
| `dompurify` | `USE_PROFILES` prototype pollution allows event handlers | [GHSA-cj63-jhhr-wcxv](https://github.com/advisories/GHSA-cj63-jhhr-wcxv) |
| `ajv` | ReDoS when using `$data` option | [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6) |
| `brace-expansion` | Zero-step sequence causes process hang and memory exhaustion | [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) |

> `brace-expansion` fix also covers `@eslint/config-array`, `@eslint/eslintrc`, and `eslint`.
