### PR TITLE
Vermeld gewenste verhoudingen bij afbeeldingen in beheer scherm

### DIFF
--- a/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
+++ b/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
@@ -100,8 +100,9 @@ const uploadImage = async (type: ImageType, file: File) => {
   state[type].error = null;
   state[type].success = null;
 
-  if (file.name.endsWith(".svg") && !(await validSvg(file))) {
-    state[type].error = "Upload mislukt: ongeldig SVG-bestand.";
+  if (file.name.endsWith(".svg") && !(await isValidSvg(file))) {
+    state[type].error =
+      "Upload mislukt: controleer of het bestand een geldig SVG-bestand is en een viewBox-attribuut bevat.";
     state[type].isUploading = false;
 
     return;
@@ -132,7 +133,7 @@ const uploadImage = async (type: ImageType, file: File) => {
   }
 };
 
-function validSvg(file: File): Promise<boolean> {
+async function isValidSvg(file: File): Promise<boolean> {
   return new Promise((resolve) => {
     const reader = new FileReader();
 

--- a/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
+++ b/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
@@ -58,9 +58,9 @@ import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import UtrechtAlert from "@/components/UtrechtAlert.vue";
 import AfbeeldingFieldset from "@/components/beheer/AfbeeldingFieldset.vue";
 
-const helpLogo = `Het logo wordt in het burgerportaal linksboven op iedere pagina getoond. De volgende bestandsformaten worden ondersteund: SVG, PNG, JPG, GIF, WebP. Maximale bestandsgrootte: 2 MB.`;
-const helpFavicon = `Het favicon wordt door webbrowsers getoond in de URL-balk en/of op het browser-tabblad. De volgende bestandsformaten worden ondersteund: ICO, SVG, PNG. Maximale bestandsgrootte: 512 KB.`;
-const helpImage = `De sfeerfoto wordt in het burgerportaal op iedere pagina bovenaan onder de menubalk getoond. De volgende bestandsformaten worden ondersteund: SVG, PNG, JPG, GIF, WebP. Maximale bestandsgrootte: 5 MB.`;
+const helpLogo = `Het logo wordt in het burgerportaal linksboven op iedere pagina getoond. De beschikbare ruimte voor het logo wordt bepaald door de NL Design System tokens van de organisatie. Het logo wordt automatisch geschaald binnen deze ruimte. Een liggend (landscape) logo werkt over het algemeen het beste. De volgende bestandsformaten worden ondersteund: SVG, PNG, JPG, GIF, WebP. Maximale bestandsgrootte: 2 MB.`;
+const helpFavicon = `Het favicon wordt door webbrowsers getoond in de URL-balk en/of op het browser-tabblad. Het wordt zeer klein weergegeven (vaak 16×16 of 32×32 pixels), dus gebruik bij voorkeur een eenvoudig, herkenbaar icoon. De volgende bestandsformaten worden ondersteund: ICO, SVG, PNG. Maximale bestandsgrootte: 512 KB.`;
+const helpImage = `De sfeerfoto wordt in het burgerportaal op iedere pagina bovenaan onder de menubalk getoond. De afbeelding wordt over de volledige breedte van de pagina weergegeven en automatisch bijgesneden (niet vervormd). De zichtbare hoogte en breedte hangen af van de schermgrootte en de inhoud die over de foto heen wordt getoond. Gebruik een liggende (landscape) afbeelding met voldoende resolutie (minimaal 1920 pixels breed aanbevolen) voor een goed resultaat op grote schermen. De volgende bestandsformaten worden ondersteund: SVG, PNG, JPG, GIF, WebP. Maximale bestandsgrootte: 5 MB.`;
 
 type ImageType = "logo" | "favicon" | "image";
 

--- a/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
+++ b/odbp.client/src/views/beheer/BeheerAfbeeldingenView.vue
@@ -100,6 +100,13 @@ const uploadImage = async (type: ImageType, file: File) => {
   state[type].error = null;
   state[type].success = null;
 
+  if (file.name.endsWith(".svg") && !(await validSvg(file))) {
+    state[type].error = "Upload mislukt: ongeldig SVG-bestand.";
+    state[type].isUploading = false;
+
+    return;
+  }
+
   try {
     const body = new FormData();
 
@@ -124,6 +131,25 @@ const uploadImage = async (type: ImageType, file: File) => {
     state[type].isUploading = false;
   }
 };
+
+function validSvg(file: File): Promise<boolean> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(reader.result as string, "image/svg+xml");
+      const svg = doc.querySelector("svg");
+
+      // check SVG parses and has viewBox attribute (basic check for valid SVG)
+      resolve(svg?.hasAttribute("viewBox") ?? false);
+    };
+
+    reader.onerror = () => resolve(false);
+
+    reader.readAsText(file);
+  });
+}
 </script>
 
 <style lang="scss" scoped>
@@ -140,8 +166,8 @@ form {
   @media screen and (min-width: #{variables.$breakpoint-md}) {
     grid-template-columns: 1fr 1fr;
     grid-template-areas:
-    "logo favicon"
-    "image image";
+      "logo favicon"
+      "image image";
   }
 }
 

--- a/odbp.client/src/views/beheer/BeheerHomeView.vue
+++ b/odbp.client/src/views/beheer/BeheerHomeView.vue
@@ -1,6 +1,10 @@
 <template>
   <utrecht-heading :level="2" :id="headingId">Homepage</utrecht-heading>
 
+  <utrecht-alert v-if="success" type="ok">
+    {{ success }}
+  </utrecht-alert>
+
   <simple-spinner v-if="isFetching" />
 
   <utrecht-alert v-else-if="error" type="error">
@@ -79,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { useId } from "vue";
+import { ref, useId } from "vue";
 import { useCloned } from "@vueuse/core";
 import { useFetchApi } from "@/api";
 import CkEditor from "@/components/ckeditor";
@@ -93,6 +97,8 @@ const videoUrlPattern =
 type HomepageBeheer = { welcome: string; videoUrl: string };
 
 const headingId = useId();
+
+const success = ref<string | null>(null);
 
 const {
   data,
@@ -115,5 +121,14 @@ const { cloned: homepage, isModified, sync } = useCloned(data);
 
 const get = () => getHomepage().execute();
 
-const submit = () => putHomepage(homepage).execute();
+const submit = () =>
+  putHomepage(homepage)
+    .execute()
+    .then(() => {
+      if (!error.value) {
+        success.value = "Publiceren gelukt.";
+
+        setTimeout(() => (success.value = null), 3000);
+      }
+    });
 </script>

--- a/odbp.client/src/views/beheer/BeheerLayout.vue
+++ b/odbp.client/src/views/beheer/BeheerLayout.vue
@@ -138,4 +138,8 @@ const links = {
 
   cursor: text;
 }
+
+.utrecht-alert {
+  --utrecht-alert-margin-block-start: 1rem;
+}
 </style>

--- a/odbp.client/src/views/beheer/BeheerLinksView.vue
+++ b/odbp.client/src/views/beheer/BeheerLinksView.vue
@@ -1,6 +1,10 @@
 <template>
   <utrecht-heading :level="2">Externe links</utrecht-heading>
 
+  <utrecht-alert v-if="success" type="ok">
+    {{ success }}
+  </utrecht-alert>
+
   <simple-spinner v-if="isFetching" />
 
   <utrecht-alert v-else-if="error" type="error">
@@ -53,6 +57,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import { useCloned } from "@vueuse/core";
 import { useFetchApi } from "@/api";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
@@ -70,6 +75,8 @@ type Links = {
   contactUrl: string;
   a11yUrl: string;
 };
+
+const success = ref<string | null>(null);
 
 const {
   data,
@@ -92,5 +99,14 @@ const { cloned: links, isModified, sync } = useCloned(data);
 
 const get = () => getLinks().execute();
 
-const submit = () => putLinks(links).execute();
+const submit = () =>
+  putLinks(links)
+    .execute()
+    .then(() => {
+      if (!error.value) {
+        success.value = "Publiceren gelukt.";
+
+        setTimeout(() => (success.value = null), 3000);
+      }
+    });
 </script>


### PR DESCRIPTION
#245

In hetzelfde component een basic SVG-check toegevoegd. SVG's zonder `viewBox` attr. hebben onvoorspelbaar 'schaalgedrag'.